### PR TITLE
Cmj pack

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dag-builder-js",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "description": "dag-builder-js is a simple-to-use Javascript DAG library with support to N:N vertices/edges. It supports validating that no cycle can be created in real-time, import/export states and it's built on SVG so you can render graphs pretty much anywhere.",
   "main": "dist/dag.js",
   "scripts": {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -2,15 +2,12 @@ const path = require('path');
 
 const common = {
     devtool: 'source-map',
+
     optimization: {
         usedExports: true,
     },
 
-    entry: './src/dag.js',
-
-    experiments: {
-        outputModule: true,
-    },
+    entry: './src/dag.js',    
 
     module: {
         rules: [
@@ -20,12 +17,22 @@ const common = {
             },
         ],
     },
-}
+};
+
+const es = {
+
+    experiments: {
+        outputModule: true,
+    },
+
+    ...common
+};
 
 module.exports = [
+    // ES module... at this point this is still experimental for webpack :(
     {
         mode: 'production',
-        
+
         output: {
             filename: 'dag.js',
             path: path.resolve(__dirname, 'dist'),
@@ -34,7 +41,7 @@ module.exports = [
             },
         },
     
-        ...common
+        ...es
     },
     {
         mode: 'development',
@@ -44,6 +51,33 @@ module.exports = [
             path: path.resolve(__dirname, 'dist'),
             library: {
                 type: 'module',
+            },
+        },
+    
+        ...es
+    },
+    // Common JS
+    {
+        mode: 'production',
+        
+        output: {
+            filename: 'dag.cmj.js',
+            path: path.resolve(__dirname, 'dist'),
+            library: {
+                type: 'commonjs2',
+            },
+        },
+    
+        ...common
+    },
+    {
+        mode: 'development',
+        
+        output: {
+            filename: 'dag.cmj.debug.js',
+            path: path.resolve(__dirname, 'dist'),
+            library: {
+                type: 'commonjs2',
             },
         },
     


### PR DESCRIPTION
webpack bundle generation for ES is experimental and some weird issues happen when you try to import those bundles into another webpacl project. The same problem doesn't happen when using common js bundles